### PR TITLE
Improve dark mode toggle

### DIFF
--- a/my-portfolio/index.html
+++ b/my-portfolio/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Amit's Portfolio</title>
     <script>
       const saved = localStorage.getItem('theme');

--- a/my-portfolio/src/components/Navbar.jsx
+++ b/my-portfolio/src/components/Navbar.jsx
@@ -1,27 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { useTheme } from '../hooks/useTheme.js';
 
 export const Navbar = ({ menuOpen, setMenuOpen }) => {
-    const [darkMode, setDarkMode] = useState(() => {
-        const stored = localStorage.getItem('theme');
-        if (stored) {
-            return stored === 'dark';
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches;
-    });
+    const [darkMode, setDarkMode] = useTheme();
 
     useEffect(() => {
         document.body.style.overflow = menuOpen ? "hidden" : "";
     }, [menuOpen]);
 
-    useEffect(() => {
-        if (darkMode) {
-            document.documentElement.classList.add('dark');
-            localStorage.setItem('theme', 'dark');
-        } else {
-            document.documentElement.classList.remove('dark');
-            localStorage.setItem('theme', 'light');
-        }
-    }, [darkMode]);
 
     return (
         <nav className="fixed top-0 w-full z-40 bg-white/80 dark:bg-[rgba(10,10,10,0.8)] backdrop-blur-lg border-b border-black/10 dark:border-white/10 shadow-lg">

--- a/my-portfolio/src/hooks/useTheme.js
+++ b/my-portfolio/src/hooks/useTheme.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+export const useTheme = () => {
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      return stored === 'dark';
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    const classList = document.documentElement.classList;
+    if (darkMode) {
+      classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [darkMode]);
+
+  return [darkMode, setDarkMode];
+};


### PR DESCRIPTION
## Summary
- encapsulate theme logic in a `useTheme` hook
- refactor `Navbar` to use the custom hook
- add `color-scheme` meta tag for better mobile support

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852cb5112a48322ad26fd8eae86378a