### PR TITLE
Fix theme toggle in navbar

### DIFF
--- a/my-portfolio/src/components/Navbar.jsx
+++ b/my-portfolio/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useTheme } from '../hooks/useTheme.js';
 
 export const Navbar = ({ menuOpen, setMenuOpen }) => {
-    const [darkMode, setDarkMode] = useTheme();
+    const [darkMode, toggleTheme] = useTheme();
 
     useEffect(() => {
         document.body.style.overflow = menuOpen ? "hidden" : "";
@@ -26,7 +26,7 @@ export const Navbar = ({ menuOpen, setMenuOpen }) => {
                     </button>
 
                     <button
-                        onClick={() => setDarkMode(!darkMode)}
+                        onClick={toggleTheme}
                         aria-label="Toggle theme"
                         className={`ml-4 w-12 h-6 flex items-center rounded-full p-1 transition-colors ${darkMode ? 'bg-yellow-400' : 'bg-gray-300'}`}
                     >

--- a/my-portfolio/src/hooks/useTheme.js
+++ b/my-portfolio/src/hooks/useTheme.js
@@ -1,27 +1,20 @@
 import { useState, useEffect } from 'react';
 
 export const useTheme = () => {
-  const [darkMode, setDarkMode] = useState(() => {
-    const stored = localStorage.getItem('theme');
-    if (stored === 'dark' || stored === 'light') {
-      return stored === 'dark';
-    }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
-  });
+  const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
-    const classList = document.documentElement.classList;
-    const meta = document.querySelector('meta[name="color-scheme"]');
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setDarkMode(stored ? stored === 'dark' : prefersDark);
+  }, []);
 
-    if (darkMode) {
-      classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-      meta?.setAttribute('content', 'dark light');
-    } else {
-      classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-      meta?.setAttribute('content', 'light dark');
-    }
+  useEffect(() => {
+    const root = document.documentElement;
+    const meta = document.querySelector('meta[name="color-scheme"]');
+    root.classList.toggle('dark', darkMode);
+    meta?.setAttribute('content', darkMode ? 'dark light' : 'light dark');
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
   }, [darkMode]);
 
   useEffect(() => {
@@ -34,5 +27,6 @@ export const useTheme = () => {
     return () => mq.removeEventListener('change', handle);
   }, []);
 
-  return [darkMode, setDarkMode];
+  const toggleTheme = () => setDarkMode((prev) => !prev);
+  return [darkMode, toggleTheme];
 };


### PR DESCRIPTION
## Summary
- revise useTheme hook to return a toggle function and simplify dark mode handling
- update Navbar to use new toggleTheme function

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852ced841bc8322bd599c135324713b